### PR TITLE
fix: actualizar configuración de Cloudflare Pages para corregir errores de despliegue

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,11 +30,11 @@ jobs:
       - name: Build
         run: npm run build
 
+      - name: Install Wrangler
+        run: npm install -g wrangler
+
       - name: Deploy to Cloudflare Pages
-        uses: cloudflare/pages-action@v1
-        with:
-          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
-          projectName: markreader
-          directory: dist
-          gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+        run: wrangler pages deploy dist --project-name=markreader --commit-dirty=true
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,19 +1,11 @@
 name = "markreader"
-main = "./.cloudflare/workers-site/index.js"
 compatibility_date = "2023-01-01"
 account_id = "8eae083cc304359a42f4b0ac69536521"
 
-[site]
-bucket = "./dist"
-
-[build]
-command = "npm run build"
-
-[pages]
-pages_build_output_dir = "./dist"
+# Configuración para Pages
+pages_build_output_dir = "dist"
 
 # Configuración para dominio personalizado
-[env.production]
 routes = [
   { pattern = "markreader.reshape.so", custom_domain = true }
 ]

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,11 +1,5 @@
 name = "markreader"
 compatibility_date = "2023-01-01"
-account_id = "8eae083cc304359a42f4b0ac69536521"
 
 # Configuración para Pages
 pages_build_output_dir = "dist"
-
-# Configuración para dominio personalizado
-routes = [
-  { pattern = "markreader.reshape.so", custom_domain = true }
-]


### PR DESCRIPTION
## Descripción

Este PR corrige los problemas relacionados con el despliegue en Cloudflare Pages, específicamente:

- Actualiza la configuración en `wrangler.toml` para eliminar configuraciones conflictivas y simplificar la estructura
- Actualiza el flujo de trabajo de GitHub Actions para usar `wrangler pages deploy` en lugar de la acción obsoleta `cloudflare/pages-action`

## Cambios realizados

### En wrangler.toml:
- Eliminada la configuración redundante y conflictiva
- Movido `pages_build_output_dir = "dist"` al nivel principal
- Simplificada la estructura de configuración

### En .github/workflows/deploy.yml:
- Reemplazada la acción obsoleta con el comando directo de Wrangler
- Añadida la instalación de Wrangler como paso previo al despliegue

## Pruebas realizadas
- Verificación local con `wrangler pages dev dist --local`
- Construcción exitosa del proyecto con la nueva configuración

## Notas adicionales
Estos cambios deberían resolver las advertencias:
- `wrangler pages publish` is deprecated and will be removed in the next major version
- Pages now has wrangler.toml support... missing the "pages_build_output_dir" field